### PR TITLE
Mac OS X (10.10 Yosemite) compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,19 @@ include(cmake/boost-python.cmake)
 pkg_check_modules(OpenCV opencv)
 include_directories(${OpenCV_INCLUDE_DIRS})
 
+include(FindPythonLibs)
+find_package(PythonLibs REQUIRED)
 # Include python (use -D flags instead)
 if (NOT PYTHON_INCLUDE_DIRS OR NOT PYTHON_LIBRARY)
     SET(PYTHON_INCLUDE_DIRS "/usr/include/python2.7")
-    SET(PYTHON_LIBRARY "/usr/lib/python2.7/config/libpython2.7.so")
+    SET(PYTHON_LIBRARY "/usr/lib/python2.7/config/libpython2.7")
 endif()
+
+# not including this causes compilation error later, as the compiler cannot find the NumPy C headers location
+if (NOT NUMPY_INCLUDE_DIRS)
+	execute_process( COMMAND "${PYTHON_EXECUTABLE}" "-c" "import numpy; print numpy.get_include();" OUTPUT_VARIABLE NUMPY_INCLUDE_DIRS OUTPUT_STRIP_TRAILING_WHITESPACE )
+endif()
+include_directories(${NUMPY_INCLUDE_DIRS})
 
 # Build np<=>opencv converter library
 boost_python_module(np_opencv_converter np_opencv_converter.cpp utils/conversion.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 
 # not including this causes compilation error later, as the compiler cannot find the NumPy C headers location
 if (NOT NUMPY_INCLUDE_DIRS)
-	execute_process( COMMAND "${PYTHON_EXECUTABLE}" "-c" "import numpy; print numpy.get_include();" OUTPUT_VARIABLE NUMPY_INCLUDE_DIRS OUTPUT_STRIP_TRAILING_WHITESPACE )
+	execute_process( COMMAND python -c "import numpy; print numpy.get_include();" OUTPUT_VARIABLE NUMPY_INCLUDE_DIRS OUTPUT_STRIP_TRAILING_WHITESPACE )
 endif()
 include_directories(${NUMPY_INCLUDE_DIRS})
 

--- a/np_opencv_converter.cpp
+++ b/np_opencv_converter.cpp
@@ -3,6 +3,9 @@
 // Last modified: Sep 14, 2014
 
 #include "np_opencv_converter.hpp"
+BOOST_PYTHON_MODULE(np_opencv_converter) {
+    // TODO: does this need to be filled in ?
+}
 
 namespace fs { namespace python {
 

--- a/tests/np_opencv_module.cpp
+++ b/tests/np_opencv_module.cpp
@@ -32,7 +32,10 @@ cv::Mat test_with_args(const cv::Mat_<float>& in, const int& var1 = 1,
 class GenericWrapper {
  public: 
   GenericWrapper(const int& _var_int = 1, const float& _var_float = 1.f,
-                 const double& _var_double = 1.d, const std::string& _var_string = std::string("test_string"))
+                 /* 1.d or 1.0d style doubles not supported by Clang on Mac, as of
+                  * 14 April 2015, see: https://llvm.org/bugs/show_bug.cgi?id=22381
+                  */
+                 const double& _var_double = 1.0, const std::string& _var_string = std::string("test_string"))
       : var_int(_var_int), var_float(_var_float), var_double(_var_double), var_string(_var_string)
   {
 
@@ -71,7 +74,10 @@ BOOST_PYTHON_MODULE(np_opencv_module)
   // Class
   py::class_<GenericWrapper>("GenericWrapper")
       .def(py::init<py::optional<int, float, double, std::string> >(
-          (py::arg("var_int")=1, py::arg("var_float")=1.f, py::arg("var_double")=1.d,
+               /* 1.d or 1.0d style doubles not supported by Clang on Mac, as of
+                * 14 April 2015, see: https://llvm.org/bugs/show_bug.cgi?id=22381
+                */
+          (py::arg("var_int")=1, py::arg("var_float")=1.f, py::arg("var_double")=1.0,
            py::arg("var_string")=std::string("test"))))
       .def("process", &GenericWrapper::process)
       ;

--- a/tests/test-numpy-opencv-converter.sh
+++ b/tests/test-numpy-opencv-converter.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+my_module="np_opencv_module"
+python -c "import $my_module"
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+	echo "*** $my_module loading unsuccessful"
+	exit $exit_code
+fi

--- a/tests/test-numpy-opencv-converter.sh
+++ b/tests/test-numpy-opencv-converter.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-my_module="np_opencv_module"
-python -c "import $my_module"
-exit_code=$?
-if [ $exit_code -ne 0 ]; then
-	echo "*** $my_module loading unsuccessful"
-	exit $exit_code
-fi


### PR DESCRIPTION
After these changes, I am able to build the converter under Mac OS X 10.10.3.

The addition to `np_opencv_converter.cpp` was needed, as I was otherwise getting an [ImportError](https://www.google.com/search?client=safari&rls=en&q=ImportError:+dynamic+module+does+not+define+init+function+%28initnp_opencv_converter%29&ie=UTF-8&oe=UTF-8#rls=en&q=ImportError:+dynamic+module+does+not+define+init+function) when attempting to load the module into Python. This function might have to be filled in, though.

The library still works under Linux (Ubuntu-MATE).
